### PR TITLE
fbc: EXTERN "rtlib" will still mangle internally generated symbols: v…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ Version 1.09.0
 - rtlib: freebsd: minimum thread stacksize 8192 KiB
 - sf.net #666: allow overload 'as string' with 'as zstring ptr' parameters
 - fbc: internal changes to restructure fbctools table, cache search results in fbctoolTB(), solve out fbcFindBin() parameters
+- fbc: EXTERN "rtlib" will still mangle internally generated symbols: vtable, rtti, default constructors and destructors
 
 [added]
 - fbc: add '-z fbrt' command line option to link against libfbrt*.a instead of libfb*.a

--- a/src/compiler/symb-comp.bas
+++ b/src/compiler/symb-comp.bas
@@ -109,7 +109,7 @@ private sub hBuildRtti( byval udt as FBSYMBOL ptr )
 	'' (real identifier given later during mangling)
 	symbNestBegin( udt, TRUE )
 	rtti = symbAddVar( NULL, NULL, FB_DATATYPE_STRUCT, symb.rtti.fb_rtti, 0, 0, dTB(), _
-	                   FB_SYMBATTRIB_CONST or FB_SYMBATTRIB_STATIC or FB_SYMBATTRIB_SHARED, _
+	                   FB_SYMBATTRIB_CONST or FB_SYMBATTRIB_STATIC or FB_SYMBATTRIB_SHARED or FB_SYMBATTRIB_INTERNAL, _
 	                   FB_SYMBOPT_PRESERVECASE )
 	rtti->stats or= FB_SYMBSTATS_RTTITABLE
 	symbNestEnd( TRUE )
@@ -161,7 +161,7 @@ private sub hBuildVtable( byval udt as FBSYMBOL ptr )
 	symbNestBegin( udt, TRUE )
 	dTB(0).upper = udt->udt.ext->vtableelements - 1
 	vtable = symbAddVar( NULL, NULL, typeAddrOf( FB_DATATYPE_VOID ), NULL, 0, 1, dTB(), _
-	                     FB_SYMBATTRIB_CONST or FB_SYMBATTRIB_STATIC or FB_SYMBATTRIB_SHARED, _
+	                     FB_SYMBATTRIB_CONST or FB_SYMBATTRIB_STATIC or FB_SYMBATTRIB_SHARED or FB_SYMBATTRIB_INTERNAL, _
 	                     FB_SYMBOPT_PRESERVECASE )
 	vtable->stats or= FB_SYMBSTATS_VTABLE
 	symbNestEnd( TRUE )
@@ -573,7 +573,7 @@ sub symbUdtDeclareDefaultMembers _
 			errReport( FB_ERRMSG_NEEDEXPLICITDEFCTOR )
 		else
 			'' Add default ctor
-			default.defctor = hDeclareProc( udt, INVALID, FB_DATATYPE_INVALID, FB_SYMBATTRIB_NONE, FB_PROCATTRIB_OVERLOADED or FB_PROCATTRIB_CONSTRUCTOR )
+			default.defctor = hDeclareProc( udt, INVALID, FB_DATATYPE_INVALID, FB_SYMBATTRIB_INTERNAL, FB_PROCATTRIB_OVERLOADED or FB_PROCATTRIB_CONSTRUCTOR )
 		end if
 	end if
 
@@ -585,7 +585,7 @@ sub symbUdtDeclareDefaultMembers _
 
 		if( udt->udt.ext->copyletopconst = NULL ) then
 			'' declare operator let( byref rhs as const UDT )
-			default.copyletopconst = hDeclareProc( udt, AST_OP_ASSIGN, typeSetIsConst( FB_DATATYPE_STRUCT ), FB_SYMBATTRIB_NONE, FB_PROCATTRIB_OVERLOADED or FB_PROCATTRIB_OPERATOR )
+			default.copyletopconst = hDeclareProc( udt, AST_OP_ASSIGN, typeSetIsConst( FB_DATATYPE_STRUCT ), FB_SYMBATTRIB_INTERNAL, FB_PROCATTRIB_OVERLOADED or FB_PROCATTRIB_OPERATOR )
 			symbProcCheckOverridden( default.copyletopconst, TRUE )
 		end if
 
@@ -596,7 +596,7 @@ sub symbUdtDeclareDefaultMembers _
 				'' same as with default ctor above.
 				errReport( FB_ERRMSG_NEEDEXPLICITCOPYCTORCONST )
 			else
-				default.copyctorconst = hDeclareProc( udt, INVALID, typeSetIsConst( FB_DATATYPE_STRUCT ), FB_SYMBATTRIB_NONE, FB_PROCATTRIB_OVERLOADED or FB_PROCATTRIB_CONSTRUCTOR )
+				default.copyctorconst = hDeclareProc( udt, INVALID, typeSetIsConst( FB_DATATYPE_STRUCT ), FB_SYMBATTRIB_INTERNAL, FB_PROCATTRIB_OVERLOADED or FB_PROCATTRIB_CONSTRUCTOR )
 			end if
 		end if
 
@@ -609,7 +609,7 @@ sub symbUdtDeclareDefaultMembers _
 				'' same as with default ctor above.
 				errReport( FB_ERRMSG_NEEDEXPLICITCOPYCTOR )
 			else
-				default.copyctor = hDeclareProc( udt, INVALID, FB_DATATYPE_STRUCT, FB_SYMBATTRIB_NONE, FB_PROCATTRIB_OVERLOADED or FB_PROCATTRIB_CONSTRUCTOR )
+				default.copyctor = hDeclareProc( udt, INVALID, FB_DATATYPE_STRUCT, FB_SYMBATTRIB_INTERNAL, FB_PROCATTRIB_OVERLOADED or FB_PROCATTRIB_CONSTRUCTOR )
 			end if
 		end if
 	end if
@@ -626,12 +626,12 @@ sub symbUdtDeclareDefaultMembers _
 			assert( udt->udt.ext->dtor0 = NULL )
 
 			'' Complete dtor
-			default.dtor1 = hDeclareProc( udt, INVALID, FB_DATATYPE_INVALID, FB_SYMBATTRIB_NONE, FB_PROCATTRIB_DESTRUCTOR1 )
+			default.dtor1 = hDeclareProc( udt, INVALID, FB_DATATYPE_INVALID, FB_SYMBATTRIB_INTERNAL, FB_PROCATTRIB_DESTRUCTOR1 )
 
 			'' c++? we may need other dtors too...
 			if( symbGetMangling( udt ) = FB_MANGLING_CPP ) then
 				'' Deleting dtor
-				default.dtor0 = hDeclareProc( udt, INVALID, FB_DATATYPE_INVALID, FB_SYMBATTRIB_NONE, FB_PROCATTRIB_DESTRUCTOR0 )
+				default.dtor0 = hDeclareProc( udt, INVALID, FB_DATATYPE_INVALID, FB_SYMBATTRIB_INTERNAL, FB_PROCATTRIB_DESTRUCTOR0 )
 			end if
 
 			'' Don't allow the implicit dtor to override a FINAL dtor from the base

--- a/src/compiler/symb-mangling.bas
+++ b/src/compiler/symb-mangling.bas
@@ -640,9 +640,23 @@ private function hDoCppMangling( byval sym as FBSYMBOL ptr ) as integer
 	end if
 
 	'' RTL or exclude parent?
-	if( ( (symbGetStats( sym ) and (FB_SYMBSTATS_RTL or FB_SYMBSTATS_EXCLPARENT)) <> 0 ) _
-		or ( symbGetMangling( sym ) = FB_MANGLING_RTLIB ) ) then
+	if( (symbGetStats( sym ) and (FB_SYMBSTATS_RTL or FB_SYMBSTATS_EXCLPARENT)) <> 0 ) then
 		return FALSE
+	end if
+
+	'' extern "rtlib"? disable cpp mangling
+	if( symbGetMangling( sym ) = FB_MANGLING_RTLIB ) then
+		'' disable cpp mangling only if it's not internally generated:
+		'' Internally generated symbols:
+		''   - vtable
+		''   - rtti
+		''   - default constructor / copy constructor
+		''   - default assignment operator
+		''   - default complete destructor / deleting constructor
+
+		if( (symbGetAttrib( sym ) and (FB_SYMBATTRIB_INTERNAL)) = 0 ) then
+			return FALSE
+		end if
 	end if
 
 	'' inside a namespace or class?

--- a/src/compiler/symb.bi
+++ b/src/compiler/symb.bi
@@ -188,6 +188,7 @@ enum FB_SYMBATTRIB
 	FB_SYMBATTRIB_SUFFIXED         = &h00100000
 	FB_SYMBATTRIB_VIS_PRIVATE      = &h00200000  '' UDT members only
 	FB_SYMBATTRIB_VIS_PROTECTED    = &h00400000  '' UDT members only
+	FB_SYMBATTRIB_INTERNAL         = &h00800000  '' default UDT members / vtable / rtti - affects name mangling
 end enum
 
 '' proc symbol attributes mask
@@ -211,7 +212,7 @@ end enum
 
 '' parameter modes
 enum FB_PARAMMODE
-	FB_PARAMMODE_BYVAL 			= 1				'' must start at 1! used for mangling
+	FB_PARAMMODE_BYVAL          = 1             '' must start at 1! used for mangling
 	FB_PARAMMODE_BYREF
 	FB_PARAMMODE_BYDESC
 	FB_PARAMMODE_VARARG
@@ -219,8 +220,8 @@ end enum
 
 '' call conventions
 enum FB_FUNCMODE
-	FB_FUNCMODE_STDCALL			= 1             '' ditto
-	FB_FUNCMODE_STDCALL_MS						'' ms/vb-style: don't include the @n suffix
+	FB_FUNCMODE_STDCALL         = 1             '' ditto
+	FB_FUNCMODE_STDCALL_MS                      '' ms/vb-style: don't include the @n suffix
 	FB_FUNCMODE_CDECL
 	FB_FUNCMODE_PASCAL
 	FB_FUNCMODE_THISCALL
@@ -234,15 +235,15 @@ end enum
 
 '' options when adding new symbols
 enum FB_SYMBOPT
-	FB_SYMBOPT_NONE				= &h00000000
+	FB_SYMBOPT_NONE             = &h00000000
 
-	FB_SYMBOPT_PRESERVECASE		= &h00000001
-	FB_SYMBOPT_UNSCOPE			= &h00000002
-	FB_SYMBOPT_DECLARING		= &h00000004
-	FB_SYMBOPT_MOVETOGLOB		= &h00000008
-	FB_SYMBOPT_RTL				= &h00000010
-	FB_SYMBOPT_DOHASH			= &h00000020
-	FB_SYMBOPT_CREATEALIAS		= &h00000040
+	FB_SYMBOPT_PRESERVECASE     = &h00000001
+	FB_SYMBOPT_UNSCOPE          = &h00000002
+	FB_SYMBOPT_DECLARING        = &h00000004
+	FB_SYMBOPT_MOVETOGLOB       = &h00000008
+	FB_SYMBOPT_RTL              = &h00000010
+	FB_SYMBOPT_DOHASH           = &h00000020
+	FB_SYMBOPT_CREATEALIAS      = &h00000040
 	FB_SYMBOPT_NODUPCHECK       = &h00000080
 end enum
 


### PR DESCRIPTION
…table, rtti, default constructors and destructors

- allow EXTERN "rtlib" to better co-exist with TYPE's having member procedures and TYPE's that extends OBJECT or other TYPES
- internally generated symbols like the vtable, rtti, default constructors and destructors must be uniquely named